### PR TITLE
セキュリティルールのテスト実行環境を整備

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,7 +23,9 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
-
+ui-debug.log
+firebase-debug.log
+firestore-debug.log
 # local env files
 .env*.local
 .env

--- a/firebase.json
+++ b/firebase.json
@@ -1,0 +1,11 @@
+{
+  "emulators": {
+    "firestore": {
+      "port": 8080,
+      "host": "localhost"
+    }
+  },
+  "firestore": {
+    "rules": "firestore.rules"
+  }
+}

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,0 +1,17 @@
+rules_version = '2';
+
+service cloud.firestore {
+
+ function isAuth(){
+    //reequest.authで認証情報を取得。認証していなければnullとなる。
+    return request.auth.uid != null;
+  }
+
+  match /databases/{database}/documents {
+    match /restaurants/{restaurantId} {
+      allow get: if isAuth()
+      allow list: if isAuth()
+      allow write: if isAuth()
+    }
+  }
+}

--- a/jest.config.firebase.js
+++ b/jest.config.firebase.js
@@ -1,0 +1,21 @@
+const nextJest = require('next/jest')
+
+const createJestConfig = nextJest({
+  // Provide the path to your Next.js app to load next.config.js and .env files in your test environment
+  dir: './',
+})
+
+// Add any custom config to be passed to Jest
+/** @type {import('jest').Config} */
+const customJestConfig = {
+  // Add more setup options before each test is run
+  // setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
+
+  testEnvironment: 'node',
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/$1',
+  },
+}
+
+// createJestConfig is exported this way to ensure that next/jest can load the Next.js config which is async
+module.exports = createJestConfig(customJestConfig)

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,21 @@
+const nextJest = require('next/jest')
+
+const createJestConfig = nextJest({
+  // Provide the path to your Next.js app to load next.config.js and .env files in your test environment
+  dir: './',
+})
+
+// Add any custom config to be passed to Jest
+/** @type {import('jest').Config} */
+const customJestConfig = {
+  // Add more setup options before each test is run
+  // setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
+
+  testEnvironment: 'jest-environment-jsdom',
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/$1',
+  },
+}
+
+// createJestConfig is exported this way to ensure that next/jest can load the Next.js config which is async
+module.exports = createJestConfig(customJestConfig)

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,9 +28,11 @@
         "@babel/preset-env": "^7.20.2",
         "@babel/preset-react": "^7.18.6",
         "@babel/preset-typescript": "^7.21.0",
+        "@firebase/rules-unit-testing": "^2.0.7",
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^14.0.0",
         "@types/jest": "^29.5.1",
+        "@types/uuid": "^9.0.2",
         "babel-jest": "^29.5.0",
         "eslint-config-prettier": "^8.6.0",
         "jest": "^29.5.0",
@@ -38,7 +40,8 @@
         "prettier": "^2.8.4",
         "react-test-renderer": "^18.2.0",
         "ts-jest": "^29.0.5",
-        "typescript": "5.1.5"
+        "typescript": "5.1.5",
+        "uuid": "^9.0.0"
       },
       "engines": {
         "node": "18.x"
@@ -2734,6 +2737,63 @@
       "resolved": "https://registry.npmjs.org/@firebase/remote-config-types/-/remote-config-types-0.3.0.tgz",
       "integrity": "sha512-RtEH4vdcbXZuZWRZbIRmQVBNsE7VDQpet2qFvq6vwKLBIQRQR5Kh58M4ok3A3US8Sr3rubYnaGqZSurCwI8uMA=="
     },
+    "node_modules/@firebase/rules-unit-testing": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@firebase/rules-unit-testing/-/rules-unit-testing-2.0.7.tgz",
+      "integrity": "sha512-tioToru3AgRanuHLt650rmP9oeyhyc9yb3i3jtZDFz3MTpztHVFI4q6sYnIneTr9aSllsItCYYCJS5ylPOCsWg==",
+      "dev": true,
+      "dependencies": {
+        "node-fetch": "2.6.7"
+      },
+      "engines": {
+        "node": ">=10.10.0"
+      },
+      "peerDependencies": {
+        "firebase": "^9.0.0"
+      }
+    },
+    "node_modules/@firebase/rules-unit-testing/node_modules/node-fetch": {
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "dev": true,
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@firebase/rules-unit-testing/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "dev": true
+    },
+    "node_modules/@firebase/rules-unit-testing/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "dev": true
+    },
+    "node_modules/@firebase/rules-unit-testing/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dev": true,
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
     "node_modules/@firebase/storage": {
       "version": "0.11.2",
       "resolved": "https://registry.npmjs.org/@firebase/storage/-/storage-0.11.2.tgz",
@@ -4969,6 +5029,12 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.2.tgz",
       "integrity": "sha512-Q5vtl1W5ue16D+nIaW8JWebSSraJVlK+EthKn7e7UcD4KWsaSJ8BqGPXNaPghgtcn/fhvrN17Tv8ksUsQpiplw==",
+      "dev": true
+    },
+    "node_modules/@types/uuid": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.2.tgz",
+      "integrity": "sha512-kNnC1GFBLuhImSnV7w4njQkUiJi0ZXUycu1rUaouPqiKlXkh77JKgdRnTAp1x5eBwcIwbtI+3otwzuIDEuDoxQ==",
       "dev": true
     },
     "node_modules/@types/yargs": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,9 @@
     "dev": "next dev -p 3333",
     "build": "next build",
     "start": "next start",
+    "test": "jest",
+    "test:firebase": "jest --config jest.config.firebase.js",
+    "test:rules": "firebase emulators:exec --only firestore 'npx jest --detectOpenHandles'",
     "lint": "next lint",
     "lint:types": "tsc --noEmit"
   },
@@ -33,9 +36,11 @@
     "@babel/preset-env": "^7.20.2",
     "@babel/preset-react": "^7.18.6",
     "@babel/preset-typescript": "^7.21.0",
+    "@firebase/rules-unit-testing": "^2.0.7",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^14.0.0",
     "@types/jest": "^29.5.1",
+    "@types/uuid": "^9.0.2",
     "babel-jest": "^29.5.0",
     "eslint-config-prettier": "^8.6.0",
     "jest": "^29.5.0",
@@ -43,6 +48,7 @@
     "prettier": "^2.8.4",
     "react-test-renderer": "^18.2.0",
     "ts-jest": "^29.0.5",
-    "typescript": "5.1.5"
+    "typescript": "5.1.5",
+    "uuid": "^9.0.0"
   }
 }

--- a/src/app/firebase.test.ts
+++ b/src/app/firebase.test.ts
@@ -1,0 +1,81 @@
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+import {
+  initializeTestEnvironment,
+  RulesTestEnvironment,
+  assertFails,
+} from '@firebase/rules-unit-testing'
+
+import { collection, doc, getDoc, setDoc } from 'firebase/firestore'
+import { v4 as uuidv4 } from 'uuid'
+
+const rulesPath = resolve(__dirname, '../../firestore.rules')
+const rules = readFileSync(rulesPath, 'utf8')
+
+// const projectId = 'test-project-' + uuidv4()
+const projectId = 'fortnite-news-1698d'
+let testEnv: RulesTestEnvironment
+const uid = uuidv4()
+const collectionName = 'restaurants'
+const docId = uuidv4()
+
+export const initTest = async () => {
+  const env = await initializeTestEnvironment({
+    projectId,
+    firestore: {
+      rules,
+      port: 8080,
+      host: '127.0.0.1',
+    },
+  })
+  return env
+}
+beforeAll(async () => {
+  // テストプロジェクト環境の作成
+  testEnv = await initTest()
+})
+
+afterAll(async () => {
+  await testEnv.cleanup()
+})
+
+const getDB = () => {
+  // ログイン情報つきのContextを作成し、そこから Firestore インスタンスを得る。
+  // authenticatedContextは引数をUIDにもつ認証済みContextを返す。
+  const authenticatedContext = testEnv.authenticatedContext(uid)
+  const clientDB = authenticatedContext.firestore()
+
+  // ゲストContextを作成し、そこから Firestore インスタンスを得る。
+  // unauthenticatedContextは未認証Contextを返す。
+  const unauthenticatedContext = testEnv.unauthenticatedContext()
+  const guestClientDB = unauthenticatedContext.firestore()
+  return { clientDB, guestClientDB }
+}
+
+describe('ドキュメントの取得', () => {
+  beforeEach(async () => {
+    await testEnv.withSecurityRulesDisabled(async (context) => {
+      const admin = context.firestore()
+      const col = collection(admin, collectionName)
+      const docRef = doc(col, docId)
+      await setDoc(docRef, { name: 'レストラン１' })
+
+      return Promise.resolve()
+    })
+  })
+
+  it('認証済みで条件を満たす場合は可能', async () => {
+    const { clientDB } = getDB()
+    const testCol = collection(clientDB, 'restaurants')
+    const docRef = doc(testCol, docId)
+    const docSnap = await getDoc(docRef)
+    expect(docSnap.exists()).toBe(true)
+  })
+
+  it('認証してない場合は不可能', async () => {
+    const { guestClientDB } = getDB()
+    const testCol = collection(guestClientDB, 'restaurants')
+    const docRef = doc(testCol, docId)
+    await assertFails(getDoc(docRef))
+  })
+})


### PR DESCRIPTION
## このPRについて

resolve #6 対応

## 変更点

- Firebaseのセキュリティルールのテスト実行出来るようにJestを設定
  - 今後Next側のテストも書くかもしれないため設定ファイルをそれぞれに用意
  - 理由は[こちら](https://zenn.dev/yosipy/articles/8d098a2e80d678)
- ドキュメント取得のテストケースだけ作成

## 実行結果

```sh
npm run test:firebase

> liff_sample_app@0.1.0 test:firebase
> jest --config jest.config.firebase.js

 PASS  src/app/firebase.test.ts
  ドキュメントの取得
    ✓ 認証済みで条件を満たす場合は可能 (268 ms)
    ✓ 認証してない場合は不可能 (50 ms)
```