### PR TITLE
任意の店舗に対して予約情報を登録できる機能

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -14,6 +14,11 @@ service cloud.firestore {
       allow get: if isAuth()
       allow list: if isAuth()
       allow create: if isAuth()
+
+      match /address/{addressId} {
+        allow get: if isAuth()
+        allow list: if isAuth()
+      }
     }
     match /users/{uid} {
       allow get: if isAuth()

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,17 +1,29 @@
 rules_version = '2';
 
 service cloud.firestore {
-
- function isAuth(){
-    //reequest.authで認証情報を取得。認証していなければnullとなる。
+  function isAuth(){
     return request.auth.uid != null;
+  }
+
+  function isOwner(uid){
+    return isAuth() && request.auth.uid == uid;
   }
 
   match /databases/{database}/documents {
     match /restaurants/{restaurantId} {
       allow get: if isAuth()
       allow list: if isAuth()
-      allow write: if isAuth()
+      allow create: if isAuth()
+    }
+    match /users/{uid} {
+      allow get: if isAuth()
+      allow list: if isAuth()
+
+      match /reservations/{reservationId} {
+        allow get: if isOwner(uid)
+        allow list: if isOwner(uid)
+        allow create: if isOwner(uid)
+      }
     }
   }
 }

--- a/src/app/dashboard/LineUser.tsx
+++ b/src/app/dashboard/LineUser.tsx
@@ -30,6 +30,7 @@ const LineUser = () => {
       {user ? (
         <>
           <h1>LINEログイン済</h1>
+          <p>uid: {user.uid}</p>
           <p>user: {user.displayName}</p>
           <button type='button' onClick={() => router.push('/restaurants')}>
             レストラン一覧を確認

--- a/src/app/restaurants/Restaurants.tsx
+++ b/src/app/restaurants/Restaurants.tsx
@@ -1,18 +1,12 @@
 'use client'
 
-import {
-  getDocs,
-  getDoc,
-  collection,
-  getFirestore,
-  query,
-} from 'firebase/firestore'
+import { getDocs, collection, getFirestore } from 'firebase/firestore'
 import { useRouter } from 'next/navigation'
 import React, { useEffect, useState, FC } from 'react'
 import { useAuthContext } from '@/src/app/context/auth'
 import { firebaseApp } from '@/src/app/firebase'
 
-type Restaurant = {
+export type RestaurantType = {
   id: string
   name: string
   phone: string
@@ -21,7 +15,7 @@ type Restaurant = {
 export const Restaurants: FC = () => {
   const router = useRouter()
   const authContext = useAuthContext()
-  const [restaurants, setRestaurants] = useState<Restaurant[]>()
+  const [restaurants, setRestaurants] = useState<RestaurantType[]>()
 
   useEffect(() => {
     ;(async () => {
@@ -33,7 +27,7 @@ export const Restaurants: FC = () => {
         const restaurantCollection = collection(db, collectionName)
         const restaurantSnapshot = await getDocs(restaurantCollection)
 
-        const loadedRestaurants: Restaurant[] = []
+        const loadedRestaurants: RestaurantType[] = []
         for (const doc of restaurantSnapshot.docs) {
           const name = doc.get('name')
           const phone = doc.get('phone')
@@ -63,6 +57,7 @@ export const Restaurants: FC = () => {
               <th>店舗名</th>
               <th>店舗連絡先</th>
               <th>住所</th>
+              <th>アクション</th>
             </tr>
           </thead>
           <tbody>
@@ -73,6 +68,17 @@ export const Restaurants: FC = () => {
                   <td>{restaurant.name}</td>
                   <td>{restaurant.phone}</td>
                   <td>{restaurant.prefecture}</td>
+                  <td>
+                    {' '}
+                    <button
+                      type='button'
+                      onClick={() =>
+                        router.push(`/restaurants/${restaurant.id}`)
+                      }
+                    >
+                      レストラン詳細
+                    </button>
+                  </td>
                 </tr>
               )
             })}


### PR DESCRIPTION
## このPRについて

resolve #8 対応

## 変更点

- レストラン一覧画面から詳細画面に遷移する機能がなかったので追加
- 任意の店舗に対して予約情報を登録できる機能

## 動作確認

詳細画面で予約処理をした時にFirestoreに該当ドキュメントが作成されることを確認

![screenshot 2023-07-06 12 15 29](https://github.com/h5y1m141/liff_sample_app/assets/950924/ccd85722-1c66-4c7e-9fdf-6e8de40c90b1)
