### PR TITLE
Module not found: Can't resolve 'encoding'の警告が出ていた対応

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@types/react": "18.2.14",
         "@types/react-dom": "18.2.6",
         "autoprefixer": "10.4.14",
+        "encoding": "^0.1.13",
         "eslint": "8.43.0",
         "eslint-config-next": "13.4.7",
         "firebase": "^9.17.1",
@@ -6487,6 +6488,14 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="
     },
+    "node_modules/encoding": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
+      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
+      "dependencies": {
+        "iconv-lite": "^0.6.2"
+      }
+    },
     "node_modules/end-of-stream": {
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
@@ -8357,7 +8366,6 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
       "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "dev": true,
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@types/react": "18.2.14",
     "@types/react-dom": "18.2.6",
     "autoprefixer": "10.4.14",
+    "encoding": "^0.1.13",
     "eslint": "8.43.0",
     "eslint-config-next": "13.4.7",
     "firebase": "^9.17.1",


### PR DESCRIPTION
## このPRについて

```sh
npm run dev
```

実施時に

```
Import trace for requested module:
./node_modules/@firebase/auth/node_modules/node-fetch/lib/index.js
./node_modules/@firebase/auth/dist/node-esm/index.js
./node_modules/firebase/auth/dist/index.mjs
./src/app/context/auth.tsx
- wait compiling /operation_for_reservations/page (client and server)...
- warn ./node_modules/@firebase/auth/node_modules/node-fetch/lib/index.js
Module not found: Can't resolve 'encoding' in 
```
という警告が出ていたのでその修正