### PR TITLE
Firestoreのschema検証ロジックを追加

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,8 @@
         "react": "18.2.0",
         "react-dom": "18.2.0",
         "react-to-print": "^2.14.13",
-        "tailwindcss": "3.3.2"
+        "tailwindcss": "3.3.2",
+        "zod": "^3.22.1"
       },
       "devDependencies": {
         "@babel/preset-env": "^7.20.2",
@@ -11228,6 +11229,14 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/next/node_modules/zod": {
+      "version": "3.21.4",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.21.4.tgz",
+      "integrity": "sha512-m46AKbrzKVzOzs/DZgVnG5H55N1sv1M8qZU3A8RIKbs3mrACDNeIOeilDymVb2HdmP8uwshOCF4uJ8uM9rCqJw==",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
     "node_modules/node-domexception": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
@@ -13966,9 +13975,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.21.4",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.21.4.tgz",
-      "integrity": "sha512-m46AKbrzKVzOzs/DZgVnG5H55N1sv1M8qZU3A8RIKbs3mrACDNeIOeilDymVb2HdmP8uwshOCF4uJ8uM9rCqJw==",
+      "version": "3.22.1",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.22.1.tgz",
+      "integrity": "sha512-+qUhAMl414+Elh+fRNtpU+byrwjDFOS1N7NioLY+tSlcADTx4TkCUua/hxJvxwDXcV4397/nZ420jy4n4+3WUg==",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-to-print": "^2.14.13",
-    "tailwindcss": "3.3.2"
+    "tailwindcss": "3.3.2",
+    "zod": "^3.22.1"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.20.2",

--- a/src/app/liff/restaurants/[id]/Restaurant.tsx
+++ b/src/app/liff/restaurants/[id]/Restaurant.tsx
@@ -20,7 +20,7 @@ import { firebaseApp } from '@/src/app/firebase'
 import {
   RestaurantType,
   BookableTableType,
-} from '@/src/app/liff/restaurants/Restaurants'
+} from '@/src/app/models/RestaurantModel'
 
 export const Restaurant: FC = () => {
   const params = useParams()
@@ -50,13 +50,10 @@ export const Restaurant: FC = () => {
         if (docSnapshot.exists()) {
           const name = docSnapshot.get('name')
           const phone = docSnapshot.get('phone')
-          const addressCollection = collection(docSnapshot.ref, 'address')
           const bookableTableCollection = collection(
             docSnapshot.ref,
             'bookable_tables',
           )
-          const addressSnapshot = await getDocs(addressCollection)
-          const prefecture = addressSnapshot.docs[0].get('prefecture')
           const bookableTables = await getDocs(bookableTableCollection)
           const items: BookableTableType[] = []
           bookableTables.docs.forEach((doc) => {
@@ -76,7 +73,6 @@ export const Restaurant: FC = () => {
             id: docSnapshot.id,
             name,
             phone,
-            prefecture,
             bookableTables: items,
           }
           setRestaurant(restaurant)
@@ -169,7 +165,6 @@ const Screen: FC<ScreenProps> = ({ restaurant, handleReservation }) => {
             <h3>詳細情報</h3>
             <ul>
               <li>電話番号：{restaurant.phone}</li>
-              <li>住所：{restaurant.prefecture}</li>
             </ul>
             <table style={{ width: 800, border: 1 }}>
               <thead>

--- a/src/app/liff/restaurants/[id]/Restaurant.tsx
+++ b/src/app/liff/restaurants/[id]/Restaurant.tsx
@@ -11,14 +11,28 @@ import {
   runTransaction,
 } from 'firebase/firestore'
 
-import { useRouter } from 'next/navigation'
-import React, { FC, useCallback, Suspense } from 'react'
+import { useRouter, useParams } from 'next/navigation'
+import React, { FC, useState, useEffect, useCallback, Suspense } from 'react'
 import { useRestaurant } from './useRestaurant'
+import { useAuthContext } from '@/src/app/context/auth'
 import { firebaseApp } from '@/src/app/firebase'
 import { RestaurantType } from '@/src/app/models/RestaurantModel'
 
 export const Restaurant: FC = () => {
-  const { user, restaurant, restaurantId } = useRestaurant()
+  const params = useParams()
+  const authContext = useAuthContext()
+  const [user, setUser] = useState<User>()
+  const [restaurantId, setRestaurantId] = useState('')
+
+  useEffect(() => {
+    const id = params.id
+    if (typeof id === 'string') setRestaurantId(id)
+  }, [params])
+
+  useEffect(() => {
+    if (authContext.user) setUser(authContext.user)
+  }, [authContext.user])
+  const { restaurant } = useRestaurant(restaurantId)
 
   if (!restaurant || !user || !restaurantId)
     return <div>店舗情報を読み込んでます...</div>

--- a/src/app/liff/restaurants/[id]/Restaurant.tsx
+++ b/src/app/liff/restaurants/[id]/Restaurant.tsx
@@ -1,11 +1,9 @@
 'use client'
 
+import dayjs from 'dayjs'
 import type { User } from 'firebase/auth'
-
 import {
   collection,
-  getDocs,
-  getDoc,
   doc,
   getFirestore,
   addDoc,
@@ -13,73 +11,14 @@ import {
   runTransaction,
 } from 'firebase/firestore'
 
-import { useParams, useRouter } from 'next/navigation'
-import React, { useEffect, useState, FC, useCallback, Suspense } from 'react'
-import { useAuthContext } from '@/src/app/context/auth'
+import { useRouter } from 'next/navigation'
+import React, { FC, useCallback, Suspense } from 'react'
+import { useRestaurant } from './useRestaurant'
 import { firebaseApp } from '@/src/app/firebase'
-import {
-  RestaurantType,
-  BookableTableType,
-} from '@/src/app/models/RestaurantModel'
+import { RestaurantType } from '@/src/app/models/RestaurantModel'
 
 export const Restaurant: FC = () => {
-  const params = useParams()
-  const authContext = useAuthContext()
-  const [user, setUser] = useState<User>()
-  const [restaurantId, setRestaurantId] = useState('')
-  const [restaurant, setRestaurant] = useState<RestaurantType>()
-
-  useEffect(() => {
-    const id = params.id
-    if (typeof id === 'string') setRestaurantId(id)
-  }, [params])
-
-  useEffect(() => {
-    if (authContext.user) setUser(authContext.user)
-  }, [authContext.user])
-
-  useEffect(() => {
-    ;(async () => {
-      const collectionName = 'restaurants'
-
-      if (user?.uid && restaurantId !== '') {
-        const db = getFirestore(firebaseApp)
-        const docRef = doc(db, collectionName, restaurantId)
-        const docSnapshot = await getDoc(docRef)
-
-        if (docSnapshot.exists()) {
-          const name = docSnapshot.get('name')
-          const phone = docSnapshot.get('phone')
-          const bookableTableCollection = collection(
-            docSnapshot.ref,
-            'bookable_tables',
-          )
-          const bookableTables = await getDocs(bookableTableCollection)
-          const items: BookableTableType[] = []
-          bookableTables.docs.forEach((doc) => {
-            items.push({
-              id: doc.id,
-              start_datetime: doc
-                .data()
-                .start_datetime.toDate()
-                .toLocaleString(),
-              end_datetime: doc.data().end_datetime.toDate().toLocaleString(),
-              available_reservation_requests:
-                doc.data().available_reservation_requests,
-            })
-          })
-
-          const restaurant: RestaurantType = {
-            id: docSnapshot.id,
-            name,
-            phone,
-            bookableTables: items,
-          }
-          setRestaurant(restaurant)
-        }
-      }
-    })()
-  }, [restaurantId, user?.uid])
+  const { user, restaurant, restaurantId } = useRestaurant()
 
   if (!restaurant || !user || !restaurantId)
     return <div>店舗情報を読み込んでます...</div>
@@ -180,8 +119,16 @@ const Screen: FC<ScreenProps> = ({ restaurant, handleReservation }) => {
                   restaurant.bookableTables.length > 0 &&
                   restaurant.bookableTables.map((bookableTable) => (
                     <tr key={bookableTable.id}>
-                      <td>{bookableTable.start_datetime}</td>
-                      <td>{bookableTable.end_datetime}</td>
+                      <td>
+                        {dayjs(bookableTable.start_datetime.toDate()).format(
+                          'YYYY/MM/DD HH:mm:ss',
+                        )}
+                      </td>
+                      <td>
+                        {dayjs(bookableTable.end_datetime.toDate()).format(
+                          'YYYY/MM/DD HH:mm:ss',
+                        )}
+                      </td>
                       <td>{bookableTable.available_reservation_requests}</td>
                       <td>
                         {bookableTable.available_reservation_requests !== 0 ? (

--- a/src/app/liff/restaurants/[id]/useRestaurant.ts
+++ b/src/app/liff/restaurants/[id]/useRestaurant.ts
@@ -1,0 +1,69 @@
+import type { User } from 'firebase/auth'
+import {
+  collection,
+  getDocs,
+  getDoc,
+  doc,
+  getFirestore,
+} from 'firebase/firestore'
+import { useParams } from 'next/navigation'
+import { useEffect, useState } from 'react'
+import { useAuthContext } from '@/src/app/context/auth'
+import { firebaseApp } from '@/src/app/firebase'
+import { BookableTableConverter } from '@/src/app/models/BookableTableModel'
+import {
+  RestaurantConverter,
+  RestaurantType,
+} from '@/src/app/models/RestaurantModel'
+
+export const useRestaurant = () => {
+  const params = useParams()
+  const authContext = useAuthContext()
+  const [user, setUser] = useState<User>()
+  const [restaurantId, setRestaurantId] = useState('')
+  const [restaurant, setRestaurant] = useState<RestaurantType>()
+
+  useEffect(() => {
+    const id = params.id
+    if (typeof id === 'string') setRestaurantId(id)
+  }, [params])
+
+  useEffect(() => {
+    if (authContext.user) setUser(authContext.user)
+  }, [authContext.user])
+
+  useEffect(() => {
+    ;(async () => {
+      const collectionName = 'restaurants'
+
+      if (user?.uid && restaurantId !== '') {
+        const db = getFirestore(firebaseApp)
+        const docRef = doc(db, collectionName, restaurantId).withConverter(
+          RestaurantConverter,
+        )
+        const docSnapshot = await getDoc(docRef)
+        const restaurant = docSnapshot.data()
+        const bookableTableCollection = collection(
+          docSnapshot.ref,
+          'bookable_tables',
+        ).withConverter(BookableTableConverter)
+        const bookableTableSnapshot = await getDocs(bookableTableCollection)
+        const bookableTables = bookableTableSnapshot.docs.map((doc) =>
+          doc.data(),
+        )
+        if (!restaurant) throw new Error('restaurant is not found')
+
+        setRestaurant({
+          ...restaurant,
+          bookableTables,
+        })
+      }
+    })()
+  }, [restaurantId, user?.uid])
+
+  return {
+    restaurantId,
+    restaurant,
+    user,
+  }
+}

--- a/src/app/liff/restaurants/[id]/useRestaurant.ts
+++ b/src/app/liff/restaurants/[id]/useRestaurant.ts
@@ -1,4 +1,3 @@
-import type { User } from 'firebase/auth'
 import {
   collection,
   getDocs,
@@ -6,9 +5,9 @@ import {
   doc,
   getFirestore,
 } from 'firebase/firestore'
-import { useParams } from 'next/navigation'
+
 import { useEffect, useState } from 'react'
-import { useAuthContext } from '@/src/app/context/auth'
+
 import { firebaseApp } from '@/src/app/firebase'
 import { BookableTableConverter } from '@/src/app/models/BookableTableModel'
 import {
@@ -16,27 +15,14 @@ import {
   RestaurantType,
 } from '@/src/app/models/RestaurantModel'
 
-export const useRestaurant = () => {
-  const params = useParams()
-  const authContext = useAuthContext()
-  const [user, setUser] = useState<User>()
-  const [restaurantId, setRestaurantId] = useState('')
+export const useRestaurant = (restaurantId: string) => {
   const [restaurant, setRestaurant] = useState<RestaurantType>()
-
-  useEffect(() => {
-    const id = params.id
-    if (typeof id === 'string') setRestaurantId(id)
-  }, [params])
-
-  useEffect(() => {
-    if (authContext.user) setUser(authContext.user)
-  }, [authContext.user])
 
   useEffect(() => {
     ;(async () => {
       const collectionName = 'restaurants'
 
-      if (user?.uid && restaurantId !== '') {
+      if (restaurantId !== '') {
         const db = getFirestore(firebaseApp)
         const docRef = doc(db, collectionName, restaurantId).withConverter(
           RestaurantConverter,
@@ -59,11 +45,9 @@ export const useRestaurant = () => {
         })
       }
     })()
-  }, [restaurantId, user?.uid])
+  }, [restaurantId])
 
   return {
-    restaurantId,
     restaurant,
-    user,
   }
 }

--- a/src/app/models/BookableTableModel.ts
+++ b/src/app/models/BookableTableModel.ts
@@ -1,0 +1,47 @@
+import { FieldValue, Timestamp } from 'firebase/firestore'
+import type {
+  QueryDocumentSnapshot,
+  DocumentData,
+  FirestoreDataConverter,
+} from 'firebase/firestore'
+import { z } from 'zod'
+
+export const firestoreFieldValueSchema = z.custom<FieldValue>(
+  (data) => data instanceof FieldValue,
+)
+
+export const firestoreTimestampSchema = z.instanceof(Timestamp)
+
+export const BookableTableSchema = z.object({
+  id: z.string(),
+  available_reservation_requests: z.number(),
+  start_datetime: firestoreTimestampSchema,
+  end_datetime: firestoreTimestampSchema,
+  created_at: firestoreTimestampSchema,
+})
+
+export type BookableTableType = z.infer<typeof BookableTableSchema>
+
+export const BookableTableConverter: FirestoreDataConverter<BookableTableType> =
+  {
+    toFirestore(bookableTable: BookableTableType): DocumentData {
+      const { start_datetime, end_datetime, available_reservation_requests } =
+        bookableTable
+      const record = {
+        start_datetime,
+        end_datetime,
+        available_reservation_requests,
+      }
+      const parsed = BookableTableSchema.parse(record)
+      return parsed
+    },
+    fromFirestore(snapshot: QueryDocumentSnapshot): BookableTableType {
+      const data = snapshot.data()!
+      const parsed = BookableTableSchema.parse({
+        ...data,
+        id: snapshot.id,
+      })
+
+      return parsed
+    },
+  }

--- a/src/app/models/RestaurantModel.ts
+++ b/src/app/models/RestaurantModel.ts
@@ -5,13 +5,8 @@ import type {
   FirestoreDataConverter,
 } from 'firebase/firestore'
 import { serverTimestamp } from 'firebase/firestore'
+import { BookableTableType } from '@/src/app/models/BookableTableModel'
 
-export type BookableTableType = {
-  id: string
-  start_datetime: string
-  end_datetime: string
-  available_reservation_requests: number
-}
 export type RestaurantType = {
   id: string
   name: string

--- a/src/app/models/RestaurantModel.ts
+++ b/src/app/models/RestaurantModel.ts
@@ -1,0 +1,42 @@
+import type {
+  QueryDocumentSnapshot,
+  DocumentData,
+  SnapshotOptions,
+  FirestoreDataConverter,
+} from 'firebase/firestore'
+import { serverTimestamp } from 'firebase/firestore'
+
+export type BookableTableType = {
+  id: string
+  start_datetime: string
+  end_datetime: string
+  available_reservation_requests: number
+}
+export type RestaurantType = {
+  id: string
+  name: string
+  phone: string
+  bookableTables?: BookableTableType[]
+}
+
+export const RestaurantConverter: FirestoreDataConverter<RestaurantType> = {
+  toFirestore(restaurant: RestaurantType): DocumentData {
+    return {
+      name: restaurant.name,
+      phone: restaurant.phone,
+      created_at: serverTimestamp(),
+    }
+  },
+  fromFirestore(
+    snapshot: QueryDocumentSnapshot,
+    options: SnapshotOptions,
+  ): RestaurantType {
+    const data = snapshot.data(options)!
+
+    return {
+      id: snapshot.id,
+      name: data.name,
+      phone: data.phone,
+    }
+  },
+}


### PR DESCRIPTION
## このPRについて

resolve #40 

## 変更点

- LIFF側のレストラン詳細画面でFirestoreからのデータ取得のロジック変更
  - [withConverter](https://firebase.google.com/docs/reference/js/v8/firebase.firestore.FirestoreDataConverter)を利用
  - 特にFirestore固有のTimestampの部分は取得時に適切な型が付与されるように対応
- 上記修正に伴い取得したデータの表示部分のロジックも一部修正