### PR TITLE
予約申請する時に店舗の情報の詳細をふくめて登録するようにロジック修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,11 @@ Check out our [Next.js deployment documentation](https://nextjs.org/docs/deploym
 ### レストランデータ
 
 ```sh
-node scripts/seed_bookable_tables.js '{"start_datetime": "2023-07-21T11:00:00.000Z","end_datetime": "2023-07-21T16:00:00.000Z","duration": 1,"available_reservation_requests": 4, "restaurant_name": "すし一世"}'
+node scripts/seed_bookable_tables.js '{"start_datetime": "2023-08-25T11:00:00.000Z","end_datetime": "2023-08-25T16:00:00.000Z","duration": 1,"available_reservation_requests": 4, "restaurant_name": "すし田中", "latitude": 35.658034, "longitude": 139.701636}'
+
+node scripts/seed_bookable_tables.js '{"start_datetime": "2023-08-25T11:00:00.000Z","end_datetime": "2023-08-26T16:00:00.000Z","duration": 1,"available_reservation_requests": 4, "restaurant_name": "洋食こいずみ", "latitude": 35.691348, "longitude": 139.70336}'
+
+node scripts/seed_bookable_tables.js '{"start_datetime": "2023-08-25T11:00:00.000Z","end_datetime": "2023-08-28T16:00:00.000Z","duration": 1,"available_reservation_requests": 4, "restaurant_name": "てんぷら鶴吉", "latitude": 35.646715, "longitude": 139.710082 }'
 ```
 
 ### ユーザー

--- a/scripts/seed_bookable_tables.js
+++ b/scripts/seed_bookable_tables.js
@@ -26,6 +26,8 @@ const prepareParams = () => {
       duration: { type: 'integer', minimum: 1 },
       available_reservation_requests: { type: 'integer', minimum: 1 },
       restaurant_name: { type: 'string' },
+      latitude: { type: 'number' },
+      longitude: { type: 'number' },
     },
     required: [
       'start_datetime',
@@ -33,6 +35,8 @@ const prepareParams = () => {
       'duration',
       'available_reservation_requests',
       'restaurant_name',
+      'latitude',
+      'longitude',
     ],
     additionalProperties: false,
   }
@@ -55,9 +59,13 @@ const prepareParams = () => {
     args.available_reservation_requests,
   )
   const restaurantName = args.restaurant_name
+  const latitude = args.latitude
+  const longitude = args.longitude
 
   return {
     restaurantName,
+    latitude,
+    longitude,
     startDatetime,
     endDatetime,
     duration,
@@ -84,7 +92,11 @@ const createBookableTableDocument = async (
   }
 }
 
-const createRestaurantDocument = async (restaurantName) => {
+const createRestaurantDocument = async (
+  restaurantName,
+  latitude,
+  longitude,
+) => {
   try {
     const restaurantId = (
       await admin
@@ -92,6 +104,8 @@ const createRestaurantDocument = async (restaurantName) => {
         .collection('restaurants')
         .add({
           name: `${restaurantName}`,
+          latitude,
+          longitude,
           phone: `090-1234-3456`,
         })
     ).id
@@ -120,9 +134,11 @@ const main = async () => {
     endDatetime,
     duration,
     availableReservationRequests,
+    latitude,
+    longitude,
   } = prepareParams()
   let currentDatetime = startDatetime
-  const id = await createRestaurantDocument(restaurantName)
+  const id = await createRestaurantDocument(restaurantName, latitude, longitude)
   await createRestaurantAddressDocument(id)
 
   while (currentDatetime.isBefore(endDatetime)) {

--- a/src/app/models/RestaurantModel.ts
+++ b/src/app/models/RestaurantModel.ts
@@ -11,6 +11,8 @@ export type RestaurantType = {
   id: string
   name: string
   phone: string
+  latitude: number
+  longitude: number
   bookableTables?: BookableTableType[]
 }
 
@@ -19,6 +21,8 @@ export const RestaurantConverter: FirestoreDataConverter<RestaurantType> = {
     return {
       name: restaurant.name,
       phone: restaurant.phone,
+      latitude: restaurant.latitude,
+      longitude: restaurant.longitude,
       created_at: serverTimestamp(),
     }
   },
@@ -32,6 +36,8 @@ export const RestaurantConverter: FirestoreDataConverter<RestaurantType> = {
       id: snapshot.id,
       name: data.name,
       phone: data.phone,
+      latitude: data.latitude,
+      longitude: data.longitude,
     }
   },
 }


### PR DESCRIPTION
## このPRについて

resolve #53 対応

## 動作確認

1. 任意の店舗で予約を申請
2. 上記申請された後に管理画面側が参照する operation_for_reservationsコレクション配下のドキュメントは以下のように緯度経度情報も含め格納される

![screenshot 2023-08-25 8 21 07](https://github.com/h5y1m141/liff_sample_app/assets/950924/bb55d958-7645-49b1-b874-18b0cd6e8ff7)
