### PR TITLE
管理画面の予約一覧画面でエリア毎の予約状況を可視化

### DIFF
--- a/functions/package.json
+++ b/functions/package.json
@@ -7,7 +7,7 @@
     "shell": "npm run build && firebase functions:shell",
     "start": "npm run shell",
     "test": "jest",
-    "deploy": "firebase deploy --only functions",
+    "deploy": "npm run build && firebase deploy --only functions",
     "logs": "firebase functions:log"
   },
   "engines": {

--- a/functions/src/index.test.ts
+++ b/functions/src/index.test.ts
@@ -19,7 +19,7 @@ const firebaseTest = functions(
 process.env.FIRESTORE_EMULATOR_HOST = 'localhost:8080'
 
 describe('copyReservationToOperation', () => {
-  let wrapped: any
+  let wrapped
   let db
 
   beforeAll(() => {
@@ -31,25 +31,31 @@ describe('copyReservationToOperation', () => {
     const userId = (await db.collection('users').add({ name: 'test user' })).id
     const reservationId = (
       await db.collection(`users/${userId}/reservations`).add({
-        restaurant: 'restaurantRef',
-        created_at: 'test',
+        restaurant_id: 'restaurant001',
+        latitude: 35.123456,
+        longitude: 139.123456,
+        restaurant_name: 'すし大崎',
+        created_at: '2022-01-01',
       })
     ).id
     expect(userId).not.toBeNull()
     expect(reservationId).not.toBeNull()
 
     const beforeReservation = {
-      name: 'test',
+      restaurant_id: 'restaurant001',
+      latitude: 35.123456,
+      longitude: 139.123456,
+      restaurant_name: 'すし大崎',
       created_at: '2022-01-01',
-      time: '12:00',
-      partySize: 4,
-      phoneNumber: '123-456-7890',
-      email: 'test@example.com',
     }
 
     const beforeSnap = firebaseTest.firestore.makeDocumentSnapshot(
       beforeReservation,
       `users/${userId}/reservations/${reservationId}`,
+    )
+    firebaseTest.firestore.makeDocumentSnapshot(
+      { created_at: '2022-01-01' },
+      '/reservation_summaries',
     )
     const wrappedCopyReservationToOperation = firebaseTest.wrap(
       copyReservationToOperation,
@@ -66,6 +72,7 @@ describe('copyReservationToOperation', () => {
         .doc(reservationId)
         .get()
     ).data()
-    expect(operationForReservation.name).toBe('test')
+    console.info('operationForReservation', operationForReservation)
+    expect(operationForReservation.restaurant_name).toBe('すし大崎')
   })
 })

--- a/functions/src/models/ReservationModel.ts
+++ b/functions/src/models/ReservationModel.ts
@@ -1,0 +1,37 @@
+import * as admin from 'firebase-admin'
+import type { DocumentData } from 'firebase-admin/firestore'
+import { FirestoreDataConverter } from 'firebase-admin/firestore'
+
+export type ReservationType = {
+  id: string
+  restaurant_id: string
+  restaurant_name: string
+  created_at: string
+  latitude: number
+  longitude: number
+}
+
+export const reservationConverter: FirestoreDataConverter<ReservationType> = {
+  toFirestore(reservation: ReservationType): DocumentData {
+    return {
+      restaurant_name: reservation.restaurant_name,
+      latitude: reservation.latitude,
+      longitude: reservation.longitude,
+      created_at: admin.firestore.FieldValue.serverTimestamp(),
+    }
+  },
+  fromFirestore(
+    snapshot: FirebaseFirestore.QueryDocumentSnapshot<FirebaseFirestore.DocumentData>,
+  ): ReservationType {
+    const data = snapshot.data()!
+
+    return {
+      id: snapshot.id,
+      restaurant_id: data.restaurant_id,
+      restaurant_name: data.restaurant_name,
+      latitude: data.latitude,
+      longitude: data.longitude,
+      created_at: data.created_at,
+    }
+  },
+}

--- a/src/app/admin/operation_for_reservations/OperationForReservationList.tsx
+++ b/src/app/admin/operation_for_reservations/OperationForReservationList.tsx
@@ -2,11 +2,15 @@
 
 import { useRouter } from 'next/navigation'
 import React, { FC, Suspense } from 'react'
+import { Map } from '../../ui/Map'
+import { useReservationSummaries } from './useReservationSummaries'
 import { useReservations } from './useReservations'
 
 export const OperationForReservationList: FC = () => {
   const router = useRouter()
   const { reservations } = useReservations()
+  const { summaries } = useReservationSummaries()
+  console.info('summaries', summaries)
 
   return (
     <>
@@ -46,6 +50,18 @@ export const OperationForReservationList: FC = () => {
               </tbody>
             </table>
           </>
+        )}
+      </Suspense>
+      <Suspense fallback={<div>店舗単位の予約サマリーを読み込んでます...</div>}>
+        {summaries && (
+          <div>
+            <Map
+              latitude={summaries ? summaries[0].latitude : 0}
+              longitude={summaries ? summaries[0].longitude : 0}
+              isCellLayerVisible={true}
+              summaries={summaries}
+            />
+          </div>
         )}
       </Suspense>
     </>

--- a/src/app/admin/operation_for_reservations/OperationForReservationList.tsx
+++ b/src/app/admin/operation_for_reservations/OperationForReservationList.tsx
@@ -1,60 +1,12 @@
 'use client'
 
-import {
-  collection,
-  getFirestore,
-  where,
-  query,
-  onSnapshot,
-  orderBy,
-  limit,
-} from 'firebase/firestore'
-
 import { useRouter } from 'next/navigation'
-import React, { useEffect, useState, FC, Suspense } from 'react'
-import { useAuthContext } from '@/src/app/context/auth'
-import { firebaseApp } from '@/src/app/firebase'
-
-export type OperationForReservationType = {
-  id: string
-  created_at: string
-  latitude: number
-  longitude: number
-}
+import React, { FC, Suspense } from 'react'
+import { useReservations } from './useReservations'
 
 export const OperationForReservationList: FC = () => {
   const router = useRouter()
-  const authContext = useAuthContext()
-  const [reservations, setReservations] =
-    useState<OperationForReservationType[]>()
-  useEffect(() => {
-    const collectionName = 'operation_for_reservations'
-
-    if (authContext.user?.uid) {
-      const db = getFirestore(firebaseApp)
-
-      const compareDate = new Date(Date.now() - 24 * 60 * 60 * 1000)
-      const q = query(
-        collection(db, collectionName),
-        orderBy('created_at', 'desc'),
-        limit(5),
-        where('created_at', '>', compareDate),
-      )
-      const unsubscribe = onSnapshot(q, (querySnapshot) => {
-        const items: OperationForReservationType[] = []
-        querySnapshot.forEach((doc) => {
-          items.push({
-            id: doc.id,
-            latitude: doc.data().latitude,
-            longitude: doc.data().longitude,
-            created_at: doc.data().created_at.toDate().toLocaleString(),
-          })
-        })
-        setReservations(items)
-      })
-      return unsubscribe
-    }
-  }, [authContext.user?.uid])
+  const { reservations } = useReservations()
 
   return (
     <>

--- a/src/app/admin/operation_for_reservations/[id]/OperationForReservation.tsx
+++ b/src/app/admin/operation_for_reservations/[id]/OperationForReservation.tsx
@@ -4,7 +4,7 @@ import React, { FC, useRef, Suspense, useCallback } from 'react'
 import { useReactToPrint } from 'react-to-print'
 
 import { Map } from '../../../ui/Map'
-import { OperationForReservationType } from '../OperationForReservationList'
+import { OperationForReservationType } from '../useReservations'
 import { useOperationForReservation } from './useOperationForReservation'
 
 export const OperationForReservation: FC = () => {

--- a/src/app/admin/operation_for_reservations/[id]/useOperationForReservation.ts
+++ b/src/app/admin/operation_for_reservations/[id]/useOperationForReservation.ts
@@ -1,7 +1,7 @@
 import { getDoc, doc, getFirestore } from 'firebase/firestore'
 import { useParams } from 'next/navigation'
 import { useEffect, useState } from 'react'
-import { OperationForReservationType } from '../OperationForReservationList'
+import { OperationForReservationType } from '../useReservations'
 import { firebaseApp } from '@/src/app/firebase'
 
 export const useOperationForReservation = () => {

--- a/src/app/admin/operation_for_reservations/useReservationSummaries.ts
+++ b/src/app/admin/operation_for_reservations/useReservationSummaries.ts
@@ -1,0 +1,34 @@
+import { getDoc, doc, getFirestore } from 'firebase/firestore'
+import { useEffect, useState } from 'react'
+import { firebaseApp } from '@/src/app/firebase'
+
+export type SummaryType = {
+  restaurant_id: string
+  count: number
+  latitude: number
+  longitude: number
+  reserved_at: any
+}
+
+export const useReservationSummaries = () => {
+  const [summaries, setSummaries] = useState<SummaryType[]>()
+  useEffect(() => {
+    ;(async () => {
+      const collectionName = 'reservation_summaries'
+      const docId = 'gkmPjFIO88DqGMrWoUB5'
+
+      const db = getFirestore(firebaseApp)
+      const docRef = doc(db, collectionName, docId)
+      const docSnapshot = await getDoc(docRef)
+
+      if (docSnapshot.exists()) {
+        const summaries = docSnapshot.get('summaries')
+        setSummaries(summaries)
+      }
+    })()
+  }, [])
+
+  return {
+    summaries,
+  }
+}

--- a/src/app/admin/operation_for_reservations/useReservations.ts
+++ b/src/app/admin/operation_for_reservations/useReservations.ts
@@ -1,0 +1,52 @@
+import {
+  collection,
+  getFirestore,
+  where,
+  query,
+  onSnapshot,
+  orderBy,
+  limit,
+} from 'firebase/firestore'
+
+import { useState, useEffect } from 'react'
+
+import { firebaseApp } from '@/src/app/firebase'
+
+export type OperationForReservationType = {
+  id: string
+  created_at: string
+  latitude: number
+  longitude: number
+}
+
+export const useReservations = () => {
+  const [reservations, setReservations] =
+    useState<OperationForReservationType[]>()
+  useEffect(() => {
+    const collectionName = 'operation_for_reservations'
+    const db = getFirestore(firebaseApp)
+
+    const compareDate = new Date(Date.now() - 24 * 60 * 60 * 1000)
+    const q = query(
+      collection(db, collectionName),
+      orderBy('created_at', 'desc'),
+      limit(5),
+      where('created_at', '>', compareDate),
+    )
+    const unsubscribe = onSnapshot(q, (querySnapshot) => {
+      const items: OperationForReservationType[] = []
+      querySnapshot.forEach((doc) => {
+        items.push({
+          id: doc.id,
+          latitude: doc.data().latitude,
+          longitude: doc.data().longitude,
+          created_at: doc.data().created_at.toDate().toLocaleString(),
+        })
+      })
+      setReservations(items)
+    })
+    return unsubscribe
+  }, [])
+
+  return { reservations }
+}

--- a/src/app/liff/restaurants/[id]/Restaurant.tsx
+++ b/src/app/liff/restaurants/[id]/Restaurant.tsx
@@ -91,8 +91,11 @@ const Container: FC<ContainerProps> = ({ user, restaurant, restaurantId }) => {
             if (!restaurant) throw 'Document does not exist!'
 
             await addDoc(colRef, {
-              restaurantId: restaurantRef.id,
-              restaurantName: restaurant.name,
+              user_id: user.uid,
+              user_name: user.displayName,
+              user_email: user.email,
+              restaurant_id: restaurantRef.id,
+              restaurant_name: restaurant.name,
               latitude: restaurant.latitude,
               longitude: restaurant.longitude,
               created_at: serverTimestamp(),


### PR DESCRIPTION

## 変更点


- 予約が新規作成されるタイミングのfunctionsのロジックを変更
  - 管理画面のために別途用意したコレクション配下に予約内容を複製
  - 上記に加え過去の予約情報を集約したドキュメントを生成するロジックを追加
- 管理画面の予約一覧画面でエリア毎の予約状況を可視化 

## 表示確認

![screenshot 2023-08-30 13 49 50](https://github.com/h5y1m141/liff_sample_app/assets/950924/0feb62b4-b230-4288-998a-89cb6ba1e51d)
