### PR TITLE
Result型を利用したロジックに変更

### DIFF
--- a/rest_base_sample/package-lock.json
+++ b/rest_base_sample/package-lock.json
@@ -22,6 +22,7 @@
         "hbs": "^4.2.0",
         "pg": "^8.11.2",
         "reflect-metadata": "^0.1.13",
+        "result-type-ts": "^2.1.1",
         "rxjs": "^7.8.1",
         "typeorm": "^0.3.17"
       },
@@ -8308,6 +8309,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/result-type-ts": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/result-type-ts/-/result-type-ts-2.1.1.tgz",
+      "integrity": "sha512-WinT26V3bHBRxjLcjkv1R+xZjzUTNhSu3oQMxp4SGtC7gLSW2MPKyfoBtlVlv1EJ8rFZqS1Hkz1g3rpZCFb98A=="
     },
     "node_modules/retry": {
       "version": "0.13.1",

--- a/rest_base_sample/package.json
+++ b/rest_base_sample/package.json
@@ -37,6 +37,7 @@
     "hbs": "^4.2.0",
     "pg": "^8.11.2",
     "reflect-metadata": "^0.1.13",
+    "result-type-ts": "^2.1.1",
     "rxjs": "^7.8.1",
     "typeorm": "^0.3.17"
   },


### PR DESCRIPTION
## このPRについて

resolve #65 対応

## 動作確認

```sh
 curl -X POST \
-d '{"seat_id": 2}' \
-H "Content-Type: application/json" \
-H "Authorization: Bearer xxxx" \
http://localhost:4000/reservations | jq .
```

### 正常処理

```json
{
  "result": {
    "seat_id": 2,
    "created_at": "2023-09-04T06:43:34.097Z",
    "updated_at": "2023-09-04T06:43:34.097Z",
    "id": 13
  },
  "seat": {
    "id": 2,
    "restaurant_id": 1,
    "number_of_seats": 3,
    "start_at": "2023-08-22T07:00:00.000Z",
    "end_at": "2023-08-22T08:00:00.000Z",
    "created_at": "2023-08-22T06:13:12.316Z",
    "updated_at": "2023-08-22T06:13:12.316Z"
  }
}
```

### 重複した予約

該当のseats.number_of_seatsが0 になってるのに上記リクエストが送信された場合

```json
{
  "result": {
    "error": "すでに該当の席は予約されています",
    "seat": null
  }
}
```

### Token有効期限切れ

```json
{
  "error": "Unauthorized"
}
```
