### PR TITLE
クレジットカード利用機能

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,8 @@
         "@emotion/styled": "^11.11.0",
         "@line/liff": "^2.22.2",
         "@mui/material": "^5.14.1",
+        "@stripe/react-stripe-js": "^2.1.2",
+        "@stripe/stripe-js": "^2.1.2",
         "@types/node": "18.11.19",
         "@types/react": "18.2.14",
         "@types/react-dom": "18.2.6",
@@ -5026,6 +5028,24 @@
       "dependencies": {
         "@sinonjs/commons": "^3.0.0"
       }
+    },
+    "node_modules/@stripe/react-stripe-js": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@stripe/react-stripe-js/-/react-stripe-js-2.1.2.tgz",
+      "integrity": "sha512-2JcKRvOdMD698uGrY0cINLHb6XHnY24L+wlWlw2+TbI2aXlQZ9t8Mc+KssFES+EuNgISbrp7fJR3w/13epfiOw==",
+      "dependencies": {
+        "prop-types": "^15.7.2"
+      },
+      "peerDependencies": {
+        "@stripe/stripe-js": "^1.44.1 || ^2.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/@stripe/stripe-js": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@stripe/stripe-js/-/stripe-js-2.1.2.tgz",
+      "integrity": "sha512-xyB/oVoFBPLCVGRUGQphzMnfCVfWGqKLb2+v/sIJAwYlVMrS2uF4iyZHpE7Lg1DtDL5qsPxSTpUGs0kRtMdbRA=="
     },
     "node_modules/@swc/helpers": {
       "version": "0.5.1",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,8 @@
     "@emotion/styled": "^11.11.0",
     "@line/liff": "^2.22.2",
     "@mui/material": "^5.14.1",
+    "@stripe/react-stripe-js": "^2.1.2",
+    "@stripe/stripe-js": "^2.1.2",
     "@types/node": "18.11.19",
     "@types/react": "18.2.14",
     "@types/react-dom": "18.2.6",

--- a/rest_base_sample/package-lock.json
+++ b/rest_base_sample/package-lock.json
@@ -24,6 +24,7 @@
         "reflect-metadata": "^0.1.13",
         "result-type-ts": "^2.1.1",
         "rxjs": "^7.8.1",
+        "stripe": "^13.4.0",
         "typeorm": "^0.3.17"
       },
       "devDependencies": {
@@ -8875,6 +8876,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/stripe": {
+      "version": "13.4.0",
+      "resolved": "https://registry.npmjs.org/stripe/-/stripe-13.4.0.tgz",
+      "integrity": "sha512-UxvRzu46AJALIueMH3/jn++qJlOoM5s+uoHXagr36xTFOj7Knrh28WFiI73dMDkngBElK68cG3WI+LgRulHw6g==",
+      "dependencies": {
+        "@types/node": ">=8.1.0",
+        "qs": "^6.11.0"
+      },
+      "engines": {
+        "node": ">=12.*"
       }
     },
     "node_modules/strnum": {

--- a/rest_base_sample/package.json
+++ b/rest_base_sample/package.json
@@ -39,6 +39,7 @@
     "reflect-metadata": "^0.1.13",
     "result-type-ts": "^2.1.1",
     "rxjs": "^7.8.1",
+    "stripe": "^13.4.0",
     "typeorm": "^0.3.17"
   },
   "devDependencies": {

--- a/rest_base_sample/src/app.module.ts
+++ b/rest_base_sample/src/app.module.ts
@@ -13,6 +13,7 @@ import { ConfigModule } from '@nestjs/config'
 import { AuthMiddleware } from './middlewares/AuthMiddleware'
 import { ReservationsModule } from './reservations/reservations.module'
 import { TypeOrmConfigService } from './orm.config'
+import { PaymentIntentsModule } from './payment_intents/payment_intents.module';
 
 @Module({
   imports: [
@@ -25,6 +26,7 @@ import { TypeOrmConfigService } from './orm.config'
     RestaurantsModule,
     SeatsModule,
     ReservationsModule,
+    PaymentIntentsModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/rest_base_sample/src/payment_intents/dto/create-payment_intent.dto.ts
+++ b/rest_base_sample/src/payment_intents/dto/create-payment_intent.dto.ts
@@ -1,0 +1,1 @@
+export class CreatePaymentIntentDto {}

--- a/rest_base_sample/src/payment_intents/dto/update-payment_intent.dto.ts
+++ b/rest_base_sample/src/payment_intents/dto/update-payment_intent.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/mapped-types';
+import { CreatePaymentIntentDto } from './create-payment_intent.dto';
+
+export class UpdatePaymentIntentDto extends PartialType(CreatePaymentIntentDto) {}

--- a/rest_base_sample/src/payment_intents/entities/payment_intent.entity.ts
+++ b/rest_base_sample/src/payment_intents/entities/payment_intent.entity.ts
@@ -1,0 +1,1 @@
+export class PaymentIntent {}

--- a/rest_base_sample/src/payment_intents/payment_intents.controller.spec.ts
+++ b/rest_base_sample/src/payment_intents/payment_intents.controller.spec.ts
@@ -1,0 +1,20 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { PaymentIntentsController } from './payment_intents.controller';
+import { PaymentIntentsService } from './payment_intents.service';
+
+describe('PaymentIntentsController', () => {
+  let controller: PaymentIntentsController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [PaymentIntentsController],
+      providers: [PaymentIntentsService],
+    }).compile();
+
+    controller = module.get<PaymentIntentsController>(PaymentIntentsController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/rest_base_sample/src/payment_intents/payment_intents.controller.ts
+++ b/rest_base_sample/src/payment_intents/payment_intents.controller.ts
@@ -1,0 +1,45 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Body,
+  Patch,
+  Param,
+  Delete,
+} from '@nestjs/common'
+import { PaymentIntentsService } from './payment_intents.service'
+import { CreatePaymentIntentDto } from './dto/create-payment_intent.dto'
+import { UpdatePaymentIntentDto } from './dto/update-payment_intent.dto'
+
+@Controller('payment_intents')
+export class PaymentIntentsController {
+  constructor(private readonly paymentIntentsService: PaymentIntentsService) {}
+
+  @Post()
+  create(@Body() createPaymentIntentDto: CreatePaymentIntentDto) {
+    return this.paymentIntentsService.create(createPaymentIntentDto)
+  }
+
+  @Get()
+  findAll() {
+    return this.paymentIntentsService.findAll()
+  }
+
+  @Get(':id')
+  findOne(@Param('id') id: string) {
+    return this.paymentIntentsService.findOne(+id)
+  }
+
+  @Patch(':id')
+  update(
+    @Param('id') id: string,
+    @Body() updatePaymentIntentDto: UpdatePaymentIntentDto,
+  ) {
+    return this.paymentIntentsService.update(+id, updatePaymentIntentDto)
+  }
+
+  @Delete(':id')
+  remove(@Param('id') id: string) {
+    return this.paymentIntentsService.remove(+id)
+  }
+}

--- a/rest_base_sample/src/payment_intents/payment_intents.module.ts
+++ b/rest_base_sample/src/payment_intents/payment_intents.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { PaymentIntentsService } from './payment_intents.service';
+import { PaymentIntentsController } from './payment_intents.controller';
+
+@Module({
+  controllers: [PaymentIntentsController],
+  providers: [PaymentIntentsService]
+})
+export class PaymentIntentsModule {}

--- a/rest_base_sample/src/payment_intents/payment_intents.service.spec.ts
+++ b/rest_base_sample/src/payment_intents/payment_intents.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { PaymentIntentsService } from './payment_intents.service';
+
+describe('PaymentIntentsService', () => {
+  let service: PaymentIntentsService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [PaymentIntentsService],
+    }).compile();
+
+    service = module.get<PaymentIntentsService>(PaymentIntentsService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/rest_base_sample/src/payment_intents/payment_intents.service.ts
+++ b/rest_base_sample/src/payment_intents/payment_intents.service.ts
@@ -1,0 +1,37 @@
+import { Injectable } from '@nestjs/common'
+import { CreatePaymentIntentDto } from './dto/create-payment_intent.dto'
+import { UpdatePaymentIntentDto } from './dto/update-payment_intent.dto'
+import Stripe from 'stripe'
+
+@Injectable()
+export class PaymentIntentsService {
+  async create(createPaymentIntentDto: CreatePaymentIntentDto) {
+    const stripe = new Stripe(process.env.STRIPE_SECRET_KEY, {
+      apiVersion: '2023-08-16',
+    })
+
+    const paymentIntent: Stripe.PaymentIntent =
+      await stripe.paymentIntents.create({
+        amount: 50, // 最低限の金額である50円を仮設定
+        currency: 'jpy',
+      })
+
+    return { secretKey: paymentIntent.client_secret }
+  }
+
+  findAll() {
+    return `This action returns all paymentIntents`
+  }
+
+  findOne(id: number) {
+    return `This action returns a #${id} paymentIntent`
+  }
+
+  update(id: number, updatePaymentIntentDto: UpdatePaymentIntentDto) {
+    return `This action updates a #${id} paymentIntent`
+  }
+
+  remove(id: number) {
+    return `This action removes a #${id} paymentIntent`
+  }
+}

--- a/src/app/web/user_credit_cards/new/CreditCardComponent.tsx
+++ b/src/app/web/user_credit_cards/new/CreditCardComponent.tsx
@@ -1,0 +1,65 @@
+'use client'
+
+import {
+  PaymentElement,
+  LinkAuthenticationElement,
+  useStripe,
+  useElements,
+} from '@stripe/react-stripe-js'
+
+import React, { FC, useCallback, useState } from 'react'
+
+type Props = {}
+
+export const CreditCardComponent: FC<Props> = () => {
+  const stripe = useStripe()
+  const elements = useElements()
+  const [isLoading, setIsLoading] = useState(false)
+  const [message, setMessage] = useState<string | null>(null)
+
+  const handleOnSubmit = useCallback(
+    async (event: React.FormEvent<HTMLFormElement>) => {
+      event.preventDefault()
+      if (!stripe || !elements) {
+        return
+      }
+      setIsLoading(true)
+
+      const { error } = await stripe.confirmPayment({
+        elements,
+        confirmParams: {
+          return_url: `${window.location.origin}/web/restaurants`,
+        },
+      })
+
+      if (error.type === 'card_error' || error.type === 'validation_error') {
+        const errorMessage = error.message
+        if (errorMessage) setMessage(errorMessage)
+      } else {
+        setMessage('An unexpected error occured.')
+      }
+
+      setIsLoading(false)
+    },
+    [stripe, elements],
+  )
+
+  return (
+    <>
+      <form id='payment-form' onSubmit={handleOnSubmit}>
+        <LinkAuthenticationElement id='link-authentication-element' />
+        <PaymentElement />
+        <button disabled={isLoading || !stripe || !elements} id='submit'>
+          <span id='button-text'>
+            {isLoading ? (
+              <div className='spinner' id='spinner'></div>
+            ) : (
+              'Pay now'
+            )}
+          </span>
+        </button>
+        {message && <div id='payment-message'>{message}</div>}
+      </form>
+    </>
+  )
+}

--- a/src/app/web/user_credit_cards/new/Payment.tsx
+++ b/src/app/web/user_credit_cards/new/Payment.tsx
@@ -1,0 +1,73 @@
+'use client'
+
+import { Elements } from '@stripe/react-stripe-js'
+import { loadStripe } from '@stripe/stripe-js'
+import type { Stripe } from '@stripe/stripe-js'
+
+import React, { FC, useState, useEffect } from 'react'
+import { CreditCardComponent } from './CreditCardComponent'
+import { useAuthContext } from '@/src/app/context/auth'
+
+type Props = {}
+
+const backendBaseURL = process.env.NEXT_PUBLIC_BACKEND_URL
+
+export const Payment: FC<Props> = () => {
+  const authContext = useAuthContext()
+  const [stripePromise, setStripePromise] = useState<Stripe | null>(null)
+  const [stripeSecretKey, setStripeSecretKey] = useState<string | null>(null)
+  const publishableKey = process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY
+
+  const fetchOption = (data: any, token: string) => {
+    return {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        mode: 'cors',
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify(data),
+    }
+  }
+
+  useEffect(() => {
+    ;(async () => {
+      if (publishableKey) {
+        setStripePromise(await loadStripe(publishableKey))
+      }
+    })()
+  }, [publishableKey])
+
+  useEffect(() => {
+    ;(async () => {
+      if (authContext.token) {
+        const token = authContext.token
+        const res = await fetch(
+          `${backendBaseURL}/payment_intents`,
+          fetchOption({}, token),
+        )
+        const data = await res.json()
+
+        if (data) {
+          setStripeSecretKey(data.secretKey)
+        }
+      }
+    })()
+  }, [authContext])
+
+  return (
+    <>
+      <h1>クレジットカード登録画面</h1>
+      {stripeSecretKey && stripePromise && (
+        <>
+          <Elements
+            stripe={stripePromise}
+            options={{ clientSecret: stripeSecretKey }}
+          >
+            <CreditCardComponent />
+          </Elements>
+        </>
+      )}
+    </>
+  )
+}

--- a/src/app/web/user_credit_cards/new/page.tsx
+++ b/src/app/web/user_credit_cards/new/page.tsx
@@ -1,0 +1,12 @@
+import React from 'react'
+import { Payment } from './Payment'
+
+async function Page() {
+  return (
+    <>
+      <Payment />
+    </>
+  )
+}
+
+export default Page


### PR DESCRIPTION
## このPRについて

resolve #69 対応

## 変更

想定はクレカ登録画面を作る予定でしたがStripe公式のコンポーネントを利用する限りでは

1. 商品（自分のサンプルだと予約申請）画面からチェックアウトフォームに遷移
2. 遷移先のフォームで商品金額確定してるのでそれをStripeのCheckoutFormコンポーネントの例を利用した処理を呼ぶ
3. 上記２．のフォームでSubmitされるとバックエンドを通じてConfirmPaymentIntentされる

という感じになってる

今回の機能はちょっと想定のIssueから離れてるためまずはこちらを取り込みつつこの後の対応で上記の流れになるように対応

## 確認画面

とりあえず現状動作するので以下のように確認済

![screenshot 2023-09-07 14 15 22](https://github.com/h5y1m141/liff_sample_app/assets/950924/1dd065d0-a64a-42ba-b97b-42bfdd46cd1c)

Stripeのダッシュボード（売上確定してないのは単にcURLでバックエンド側の処理を呼び出しただけのもの。こちらはConfirmしてないから未確定になってる）

![screenshot 2023-09-07 14 15 44](https://github.com/h5y1m141/liff_sample_app/assets/950924/6619386c-67dd-40de-a573-c8721db01483)
