### PR TITLE
予約申請画面でキャッシュされた空席情報がフォームの選択項目に表示されてしまう不具合修正

### DIFF
--- a/src/app/web/restaurants/[id]/ReservationRequest.tsx
+++ b/src/app/web/restaurants/[id]/ReservationRequest.tsx
@@ -122,10 +122,10 @@ export const ReservationRequest: FC<Props> = ({ seats, restaurantCourses }) => {
     <>
       <h2 style={{ fontSize: '1.2rem' }}>コースを選択</h2>
       <select
-        name='seat'
-        id='select-seat'
+        name='course'
+        id='select-course'
         style={selectStyle}
-        onBlur={handleSelectSeat}
+        onBlur={handleSelectRestaurantCourse}
       >
         <option value=''>選択してください</option>
         {restaurantCourses.map((course) => {
@@ -146,7 +146,7 @@ export const ReservationRequest: FC<Props> = ({ seats, restaurantCourses }) => {
           name='seat'
           id='select-seat'
           style={selectStyle}
-          onBlur={handleSelectRestaurantCourse}
+          onBlur={handleSelectSeat}
         >
           <option value=''>選択してください</option>
           {seats.map((seat) => {
@@ -170,7 +170,6 @@ export const ReservationRequest: FC<Props> = ({ seats, restaurantCourses }) => {
           onChange={handleComment}
         />
       </div>
-
       {selectedSeat &&
       selectedRestaurantCourse &&
       stripeSecretKey &&

--- a/src/app/web/restaurants/[id]/page.tsx
+++ b/src/app/web/restaurants/[id]/page.tsx
@@ -4,11 +4,12 @@ import { ReservationRequest } from './ReservationRequest'
 
 async function fetchRestaurant(id: string) {
   const backendBaseURL = process.env.NEXT_PUBLIC_BACKEND_URL
-  const options = {
+  const options: RequestInit = {
     method: 'GET',
     headers: {
       'Content-Type': 'application/json',
     },
+    cache: 'no-store' as RequestCache,
   }
   const res = await fetch(`${backendBaseURL}/restaurants/${id}`, options)
   const result = res.ok

--- a/src/app/web/restaurants/page.tsx
+++ b/src/app/web/restaurants/page.tsx
@@ -4,11 +4,12 @@ import { Result } from 'result-type-ts'
 
 async function fetchRestaurants() {
   const backendBaseURL = process.env.NEXT_PUBLIC_BACKEND_URL
-  const options = {
+  const options: RequestInit = {
     method: 'GET',
     headers: {
       'Content-Type': 'application/json',
     },
+    cache: 'no-store' as RequestCache,
   }
   const res = await fetch(`${backendBaseURL}/restaurants`, options)
   const result = res.ok


### PR DESCRIPTION
## このPRについて

resole #75 対応

## 変更点


- バックエンド側のDBに追加で空席を登録
- その状態で予約申請画面を表示するとキャッシュされた空席情報がフォームの選択項目に表示されてしまっていたため追加された情報が残ってる

という状況だったのでキャッシュの処理を見直し
