### PR TITLE
デプロイの動作確認のため一時的にAuthのMiddlewareを停止

### DIFF
--- a/rest_base_sample/src/app.module.ts
+++ b/rest_base_sample/src/app.module.ts
@@ -2,7 +2,7 @@ import {
   MiddlewareConsumer,
   Module,
   NestModule,
-  RequestMethod,
+  // RequestMethod,
 } from '@nestjs/common'
 import { AppController } from './app.controller'
 import { AppService } from './app.service'
@@ -10,11 +10,11 @@ import { TypeOrmModule } from '@nestjs/typeorm'
 import { RestaurantsModule } from './restaurants/restaurants.module'
 import { SeatsModule } from './seats/seats.module'
 import { ConfigModule } from '@nestjs/config'
-import { AuthMiddleware } from './middlewares/AuthMiddleware'
+// import { AuthMiddleware } from './middlewares/AuthMiddleware'
 import { ReservationsModule } from './reservations/reservations.module'
 import { TypeOrmConfigService } from './orm.config'
-import { PaymentIntentsModule } from './payment_intents/payment_intents.module';
-import { RestaurantCoursesModule } from './restaurant_courses/restaurant_courses.module';
+import { PaymentIntentsModule } from './payment_intents/payment_intents.module'
+import { RestaurantCoursesModule } from './restaurant_courses/restaurant_courses.module'
 
 @Module({
   imports: [
@@ -35,12 +35,12 @@ import { RestaurantCoursesModule } from './restaurant_courses/restaurant_courses
 })
 export class AppModule implements NestModule {
   configure(consumer: MiddlewareConsumer) {
-    consumer
-      .apply(AuthMiddleware)
-      .exclude(
-        { path: 'restaurants', method: RequestMethod.GET },
-        { path: 'restaurants/:id', method: RequestMethod.GET },
-      )
-      .forRoutes('*')
+    // consumer
+    //   .apply(AuthMiddleware)
+    //   .exclude(
+    //     { path: 'restaurants', method: RequestMethod.GET },
+    //     { path: 'restaurants/:id', method: RequestMethod.GET },
+    //   )
+    //   .forRoutes('*')
   }
 }


### PR DESCRIPTION
## このPRについて

#77 対応

デプロイした後に

```
[Nest] 20  - 09/11/2023, 5:03:44 AM     LOG [RouterExplorer] Mapped {/restaurant_courses/:id, DELETE} route +0ms
[Nest] 20  - 09/11/2023, 5:03:44 AM     LOG [NestApplication] Nest application successfully started +2ms
Attempt #4 failed with status 401. Continuing to retry for 4m52s
Attempt #5 failed with status 401. Continuing to retry for 4m52s
Attempt #6 failed with status 401. Continuing to retry for 4m36s
Attempt #7 failed with status 401. Continuing to retry for 4m6s
```

という感じでNestJSのコンテナから任意のホストにリクエストを投げた時に 401 になってる。

可能性としては Firebase関連しか思いつかないのでトラブル切り分けのために一時的にAuthのMiddlewareを停止