### PR TITLE
Serviceクラスに関するテストケース修正

### DIFF
--- a/rest_base_sample/src/config/migration.config.ts
+++ b/rest_base_sample/src/config/migration.config.ts
@@ -3,13 +3,13 @@ import { DataSource } from 'typeorm'
 
 export default new DataSource({
   type: 'postgres',
-  host: process.env.DATABASE_HOST,
-  port: 5432,
+  host: 'containers-us-west-40.railway.app',
+  port: 7442,
   synchronize: false,
   logging: true,
-  username: process.env.DATABASE_USERNAME,
-  password: process.env.DATABASE_PASSWORD,
-  database: process.env.DATABASE_DATABASE,
+  username: 'postgres',
+  password: 'gRABwgb9yrv5VhDFRjc3',
+  database: 'railway',
   entities: ['src/**/entities/*.entity.ts'],
   migrations: ['migrations/*.ts'],
 })

--- a/rest_base_sample/src/payment_intents/payment_intents.controller.spec.ts
+++ b/rest_base_sample/src/payment_intents/payment_intents.controller.spec.ts
@@ -1,20 +1,94 @@
-import { Test, TestingModule } from '@nestjs/testing';
-import { PaymentIntentsController } from './payment_intents.controller';
-import { PaymentIntentsService } from './payment_intents.service';
+import { Test, TestingModule } from '@nestjs/testing'
+import { PaymentIntentsController } from './payment_intents.controller'
+import { PaymentIntentsService } from './payment_intents.service'
+import { DataSource } from 'typeorm'
+import Stripe from 'stripe'
+
+// Stripeのモックを初期化
+jest.mock('stripe', () => {
+  return {
+    __esModule: true,
+    default: jest.fn().mockImplementation(() => {
+      return {
+        paymentIntents: {
+          create: jest.fn(),
+        },
+      }
+    }),
+  }
+})
 
 describe('PaymentIntentsController', () => {
-  let controller: PaymentIntentsController;
+  let controller: PaymentIntentsController
+  let stripeInstance: any
+
+  let mockDataSource: any
+  let mockQueryRunner: any
+  let mockQueryBuilder: any
+  let mockSeatRepository: any
 
   beforeEach(async () => {
+    stripeInstance = new Stripe(process.env.STRIPE_SECRET_KEY, {
+      apiVersion: '2023-08-16',
+    })
+    stripeInstance.paymentIntents.create.mockResolvedValue({
+      client_secret: 'test_secret',
+    })
+
+    mockQueryBuilder = {
+      setLock: jest.fn().mockReturnThis(),
+      where: jest.fn().mockReturnThis(),
+      getOne: jest.fn(),
+    }
+
+    mockSeatRepository = {
+      createQueryBuilder: jest.fn().mockReturnValue(mockQueryBuilder),
+      update: jest.fn(),
+    }
+
+    mockQueryRunner = {
+      connect: jest.fn(),
+      startTransaction: jest.fn(),
+      manager: {
+        getRepository: jest.fn().mockReturnValue(mockSeatRepository),
+        update: jest.fn(),
+        save: jest.fn(),
+      },
+      commitTransaction: jest.fn(),
+      rollbackTransaction: jest.fn(),
+    }
+
+    mockDataSource = {
+      createQueryRunner: jest.fn().mockReturnValue(mockQueryRunner),
+    }
+
+    const mockStripeInstance = {
+      paymentIntents: {
+        create: jest.fn().mockResolvedValue({
+          client_secret: 'test_secret',
+        }),
+      },
+    }
+
     const module: TestingModule = await Test.createTestingModule({
       controllers: [PaymentIntentsController],
-      providers: [PaymentIntentsService],
-    }).compile();
+      providers: [
+        PaymentIntentsService,
+        {
+          provide: DataSource,
+          useValue: mockDataSource,
+        },
+        {
+          provide: Stripe,
+          useValue: mockStripeInstance,
+        },
+      ],
+    }).compile()
 
-    controller = module.get<PaymentIntentsController>(PaymentIntentsController);
-  });
+    controller = module.get<PaymentIntentsController>(PaymentIntentsController)
+  })
 
   it('should be defined', () => {
-    expect(controller).toBeDefined();
-  });
-});
+    expect(controller).toBeDefined()
+  })
+})

--- a/rest_base_sample/src/payment_intents/payment_intents.controller.ts
+++ b/rest_base_sample/src/payment_intents/payment_intents.controller.ts
@@ -19,27 +19,4 @@ export class PaymentIntentsController {
   create(@Body() createPaymentIntentDto: CreatePaymentIntentDto) {
     return this.paymentIntentsService.create(createPaymentIntentDto)
   }
-
-  @Get()
-  findAll() {
-    return this.paymentIntentsService.findAll()
-  }
-
-  @Get(':id')
-  findOne(@Param('id') id: string) {
-    return this.paymentIntentsService.findOne(+id)
-  }
-
-  @Patch(':id')
-  update(
-    @Param('id') id: string,
-    @Body() updatePaymentIntentDto: UpdatePaymentIntentDto,
-  ) {
-    return this.paymentIntentsService.update(+id, updatePaymentIntentDto)
-  }
-
-  @Delete(':id')
-  remove(@Param('id') id: string) {
-    return this.paymentIntentsService.remove(+id)
-  }
 }

--- a/rest_base_sample/src/payment_intents/payment_intents.module.ts
+++ b/rest_base_sample/src/payment_intents/payment_intents.module.ts
@@ -3,10 +3,21 @@ import { PaymentIntentsService } from './payment_intents.service'
 import { PaymentIntentsController } from './payment_intents.controller'
 import { TypeOrmModule } from '@nestjs/typeorm'
 import { PaymentIntent } from './entities/payment_intent.entity'
+import Stripe from 'stripe'
 
 @Module({
   imports: [TypeOrmModule.forFeature([PaymentIntent])],
   controllers: [PaymentIntentsController],
-  providers: [PaymentIntentsService],
+  providers: [
+    PaymentIntentsService,
+    {
+      provide: Stripe,
+      useFactory: () => {
+        return new Stripe(process.env.STRIPE_SECRET_KEY, {
+          apiVersion: '2023-08-16',
+        })
+      },
+    },
+  ],
 })
 export class PaymentIntentsModule {}

--- a/rest_base_sample/src/payment_intents/payment_intents.service.spec.ts
+++ b/rest_base_sample/src/payment_intents/payment_intents.service.spec.ts
@@ -1,18 +1,105 @@
-import { Test, TestingModule } from '@nestjs/testing';
-import { PaymentIntentsService } from './payment_intents.service';
+import { Test, TestingModule } from '@nestjs/testing'
+import { PaymentIntentsService } from './payment_intents.service'
+import { DataSource } from 'typeorm'
+import Stripe from 'stripe'
+
+// Stripeのモックを初期化
+jest.mock('stripe', () => {
+  return {
+    __esModule: true,
+    default: jest.fn().mockImplementation(() => {
+      return {
+        paymentIntents: {
+          create: jest.fn(),
+        },
+      }
+    }),
+  }
+})
 
 describe('PaymentIntentsService', () => {
-  let service: PaymentIntentsService;
+  let service: PaymentIntentsService
+  let stripeInstance: any
+
+  let mockDataSource: any
+  let mockQueryRunner: any
+  let mockQueryBuilder: any
+  let mockSeatRepository: any
 
   beforeEach(async () => {
+    // NOTE
+
+    stripeInstance = new Stripe(process.env.STRIPE_SECRET_KEY, {
+      apiVersion: '2023-08-16',
+    })
+    stripeInstance.paymentIntents.create.mockResolvedValue({
+      client_secret: 'test_secret',
+    })
+
+    mockQueryBuilder = {
+      setLock: jest.fn().mockReturnThis(),
+      where: jest.fn().mockReturnThis(),
+      getOne: jest.fn(),
+    }
+
+    mockSeatRepository = {
+      createQueryBuilder: jest.fn().mockReturnValue(mockQueryBuilder),
+      update: jest.fn(),
+    }
+
+    mockQueryRunner = {
+      connect: jest.fn(),
+      startTransaction: jest.fn(),
+      manager: {
+        getRepository: jest.fn().mockReturnValue(mockSeatRepository),
+        update: jest.fn(),
+        save: jest.fn(),
+      },
+      commitTransaction: jest.fn(),
+      rollbackTransaction: jest.fn(),
+    }
+
+    mockDataSource = {
+      createQueryRunner: jest.fn().mockReturnValue(mockQueryRunner),
+    }
+
+    const mockStripeInstance = {
+      paymentIntents: {
+        create: jest.fn().mockResolvedValue({
+          client_secret: 'test_secret',
+        }),
+      },
+    }
+
     const module: TestingModule = await Test.createTestingModule({
-      providers: [PaymentIntentsService],
-    }).compile();
+      providers: [
+        PaymentIntentsService,
+        {
+          provide: DataSource,
+          useValue: mockDataSource,
+        },
+        {
+          provide: Stripe,
+          useValue: mockStripeInstance,
+        },
+      ],
+    }).compile()
 
-    service = module.get<PaymentIntentsService>(PaymentIntentsService);
-  });
+    service = module.get<PaymentIntentsService>(PaymentIntentsService)
+  })
 
-  it('should be defined', () => {
-    expect(service).toBeDefined();
-  });
-});
+  describe('create', () => {
+    it('should handle seat reservation and return the result', async () => {
+      const dto = {
+        price: 2000,
+        seat_id: 1,
+        restaurant_course_id: 1,
+      }
+      mockQueryBuilder.getOne.mockResolvedValue({ number_of_seats: 1 })
+
+      const response = await service.create(dto)
+      expect(response.secretKey).toEqual('test_secret')
+      expect(mockQueryRunner.commitTransaction).toHaveBeenCalled()
+    })
+  })
+})

--- a/rest_base_sample/src/payment_intents/payment_intents.service.ts
+++ b/rest_base_sample/src/payment_intents/payment_intents.service.ts
@@ -9,18 +9,15 @@ import Stripe from 'stripe'
 
 @Injectable()
 export class PaymentIntentsService {
-  constructor(private dataSource: DataSource) {}
+  constructor(private dataSource: DataSource, private stripe: Stripe) {}
 
   async create(createPaymentIntentDto: CreatePaymentIntentDto) {
-    const stripe = new Stripe(process.env.STRIPE_SECRET_KEY, {
-      apiVersion: '2023-08-16',
-    })
-
     const paymentIntent: Stripe.PaymentIntent =
-      await stripe.paymentIntents.create({
+      await this.stripe.paymentIntents.create({
         amount: createPaymentIntentDto.price,
         currency: 'jpy',
       })
+
     if (paymentIntent) {
       const queryRunner = this.dataSource.createQueryRunner()
       await queryRunner.connect()
@@ -73,21 +70,5 @@ export class PaymentIntentsService {
     } else {
       return { secretKey: null, result: null, seat: null }
     }
-  }
-
-  findAll() {
-    return `This action returns all paymentIntents`
-  }
-
-  findOne(id: number) {
-    return `This action returns a #${id} paymentIntent`
-  }
-
-  update(id: number, updatePaymentIntentDto: UpdatePaymentIntentDto) {
-    return `This action updates a #${id} paymentIntent`
-  }
-
-  remove(id: number) {
-    return `This action removes a #${id} paymentIntent`
   }
 }

--- a/rest_base_sample/src/reservations/reservations.controller.spec.ts
+++ b/rest_base_sample/src/reservations/reservations.controller.spec.ts
@@ -1,20 +1,66 @@
-import { Test, TestingModule } from '@nestjs/testing';
-import { ReservationsController } from './reservations.controller';
-import { ReservationsService } from './reservations.service';
+import { Test, TestingModule } from '@nestjs/testing'
+import { ReservationsController } from './reservations.controller'
+import { ReservationsService } from './reservations.service'
+import { Reservation } from './entities/reservation.entity'
+import { mockReservationRepository } from './reservations.service.spec'
+import { getRepositoryToken } from '@nestjs/typeorm'
+import { DataSource } from 'typeorm'
 
 describe('ReservationsController', () => {
-  let controller: ReservationsController;
+  let controller: ReservationsController
+
+  let mockDataSource: any
+  let mockQueryRunner: any
+  let mockQueryBuilder: any
+  let mockSeatRepository: any
 
   beforeEach(async () => {
+    mockQueryBuilder = {
+      setLock: jest.fn().mockReturnThis(),
+      where: jest.fn().mockReturnThis(),
+      getOne: jest.fn(),
+    }
+
+    mockSeatRepository = {
+      createQueryBuilder: jest.fn().mockReturnValue(mockQueryBuilder),
+      update: jest.fn(),
+    }
+
+    mockQueryRunner = {
+      connect: jest.fn(),
+      startTransaction: jest.fn(),
+      manager: {
+        getRepository: jest.fn().mockReturnValue(mockSeatRepository),
+        update: jest.fn(),
+        save: jest.fn(),
+      },
+      commitTransaction: jest.fn(),
+      rollbackTransaction: jest.fn(),
+    }
+
+    mockDataSource = {
+      createQueryRunner: jest.fn().mockReturnValue(mockQueryRunner),
+    }
+
     const module: TestingModule = await Test.createTestingModule({
       controllers: [ReservationsController],
-      providers: [ReservationsService],
-    }).compile();
+      providers: [
+        ReservationsService,
+        {
+          provide: getRepositoryToken(Reservation),
+          useFactory: mockReservationRepository,
+        },
+        {
+          provide: DataSource,
+          useValue: mockDataSource,
+        },
+      ],
+    }).compile()
 
-    controller = module.get<ReservationsController>(ReservationsController);
-  });
+    controller = module.get<ReservationsController>(ReservationsController)
+  })
 
   it('should be defined', () => {
-    expect(controller).toBeDefined();
-  });
-});
+    expect(controller).toBeDefined()
+  })
+})

--- a/rest_base_sample/src/reservations/reservations.service.spec.ts
+++ b/rest_base_sample/src/reservations/reservations.service.spec.ts
@@ -4,7 +4,7 @@ import { Reservation } from './entities/reservation.entity'
 import { getRepositoryToken } from '@nestjs/typeorm'
 import { DataSource } from 'typeorm'
 
-const mockReservationRepository = () => ({
+export const mockReservationRepository = () => ({
   find: jest.fn(),
   findOne: jest.fn(),
 })
@@ -87,6 +87,7 @@ describe('ReservationsService', () => {
       expect(await service.findOne(result.id)).toEqual(result)
     })
   })
+
   describe('create', () => {
     it('should handle seat reservation and return the result', async () => {
       const dto = { seat_id: 1, restaurant_course_id: 1 }

--- a/rest_base_sample/src/reservations/reservations.service.spec.ts
+++ b/rest_base_sample/src/reservations/reservations.service.spec.ts
@@ -1,18 +1,104 @@
-import { Test, TestingModule } from '@nestjs/testing';
-import { ReservationsService } from './reservations.service';
+import { Test, TestingModule } from '@nestjs/testing'
+import { ReservationsService } from './reservations.service'
+import { Reservation } from './entities/reservation.entity'
+import { getRepositoryToken } from '@nestjs/typeorm'
+import { DataSource } from 'typeorm'
+
+const mockReservationRepository = () => ({
+  find: jest.fn(),
+  findOne: jest.fn(),
+})
 
 describe('ReservationsService', () => {
-  let service: ReservationsService;
+  let service: ReservationsService
+  let repository: any
+  let mockDataSource: any
+  let mockQueryRunner: any
+  let mockQueryBuilder: any
+  let mockSeatRepository: any
 
   beforeEach(async () => {
+    // NOTE
+    // テスト間でのモック関数の状態のリセットを容易にするためbeforeEachで定義
+    mockQueryBuilder = {
+      setLock: jest.fn().mockReturnThis(),
+      where: jest.fn().mockReturnThis(),
+      getOne: jest.fn(),
+    }
+
+    mockSeatRepository = {
+      createQueryBuilder: jest.fn().mockReturnValue(mockQueryBuilder),
+      update: jest.fn(),
+    }
+
+    mockQueryRunner = {
+      connect: jest.fn(),
+      startTransaction: jest.fn(),
+      manager: {
+        getRepository: jest.fn().mockReturnValue(mockSeatRepository),
+        update: jest.fn(),
+        save: jest.fn(),
+      },
+      commitTransaction: jest.fn(),
+      rollbackTransaction: jest.fn(),
+    }
+
+    mockDataSource = {
+      createQueryRunner: jest.fn().mockReturnValue(mockQueryRunner),
+    }
     const module: TestingModule = await Test.createTestingModule({
-      providers: [ReservationsService],
-    }).compile();
+      providers: [
+        ReservationsService,
+        {
+          provide: getRepositoryToken(Reservation),
+          useFactory: mockReservationRepository,
+        },
+        {
+          provide: DataSource,
+          useValue: mockDataSource,
+        },
+      ],
+    }).compile()
 
-    service = module.get<ReservationsService>(ReservationsService);
-  });
+    service = module.get<ReservationsService>(ReservationsService)
+    repository = module.get(getRepositoryToken(Reservation))
+  })
 
-  it('should be defined', () => {
-    expect(service).toBeDefined();
-  });
-});
+  describe('findAll', () => {
+    it('メソッドが定義されてる', () => {
+      expect(service.findAll).toBeDefined()
+    })
+
+    it('repositroyを通じて取得された結果を返す', async () => {
+      const result = [{ id: 1, seat_id: 1 }]
+      repository.find.mockResolvedValue(result)
+      expect(await service.findAll()).toEqual(result)
+    })
+  })
+
+  describe('findOne', () => {
+    it('メソッドが定義されてる', () => {
+      expect(service.findOne).toBeDefined()
+    })
+
+    it('repositroyを通じて取得された結果を返す', async () => {
+      const result = { id: 1, seat_id: 1 }
+      repository.findOne.mockResolvedValue(result)
+      expect(await service.findOne(result.id)).toEqual(result)
+    })
+  })
+  describe('create', () => {
+    it('should handle seat reservation and return the result', async () => {
+      const dto = { seat_id: 1, restaurant_course_id: 1 }
+      mockQueryBuilder.getOne.mockResolvedValue({ number_of_seats: 1 })
+
+      const response = await service.create(dto)
+
+      expect(mockQueryBuilder.setLock).toHaveBeenCalledWith('pessimistic_write')
+      expect(mockQueryBuilder.where).toHaveBeenCalledWith('seats.id = :id', {
+        id: dto.seat_id,
+      })
+      expect(mockQueryRunner.commitTransaction).toHaveBeenCalled()
+    })
+  })
+})

--- a/rest_base_sample/src/restaurant_courses/restaurant_courses.controller.spec.ts
+++ b/rest_base_sample/src/restaurant_courses/restaurant_courses.controller.spec.ts
@@ -1,20 +1,35 @@
-import { Test, TestingModule } from '@nestjs/testing';
-import { RestaurantCoursesController } from './restaurant_courses.controller';
-import { RestaurantCoursesService } from './restaurant_courses.service';
+import { Test, TestingModule } from '@nestjs/testing'
+import { RestaurantCoursesController } from './restaurant_courses.controller'
+import { RestaurantCoursesService } from './restaurant_courses.service'
+import { RestaurantCourse } from './entities/restaurant_course.entity'
+import { getRepositoryToken } from '@nestjs/typeorm'
+
+const mockRestaurantCourseRepository = () => ({
+  find: jest.fn(),
+  findOne: jest.fn(),
+})
 
 describe('RestaurantCoursesController', () => {
-  let controller: RestaurantCoursesController;
+  let controller: RestaurantCoursesController
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [RestaurantCoursesController],
-      providers: [RestaurantCoursesService],
-    }).compile();
+      providers: [
+        RestaurantCoursesService,
+        {
+          provide: getRepositoryToken(RestaurantCourse),
+          useFactory: mockRestaurantCourseRepository,
+        },
+      ],
+    }).compile()
 
-    controller = module.get<RestaurantCoursesController>(RestaurantCoursesController);
-  });
+    controller = module.get<RestaurantCoursesController>(
+      RestaurantCoursesController,
+    )
+  })
 
   it('should be defined', () => {
-    expect(controller).toBeDefined();
-  });
-});
+    expect(controller).toBeDefined()
+  })
+})

--- a/rest_base_sample/src/restaurant_courses/restaurant_courses.service.spec.ts
+++ b/rest_base_sample/src/restaurant_courses/restaurant_courses.service.spec.ts
@@ -1,18 +1,69 @@
-import { Test, TestingModule } from '@nestjs/testing';
-import { RestaurantCoursesService } from './restaurant_courses.service';
+import { Test, TestingModule } from '@nestjs/testing'
+import { RestaurantCoursesService } from './restaurant_courses.service'
+import { RestaurantCourse } from './entities/restaurant_course.entity'
+import { getRepositoryToken } from '@nestjs/typeorm'
+
+const mockRestaurantCourseRepository = () => ({
+  find: jest.fn(),
+  findOne: jest.fn(),
+})
 
 describe('RestaurantCoursesService', () => {
-  let service: RestaurantCoursesService;
+  let service: RestaurantCoursesService
+  let repository
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [RestaurantCoursesService],
-    }).compile();
+      providers: [
+        RestaurantCoursesService,
+        {
+          provide: getRepositoryToken(RestaurantCourse),
+          useFactory: mockRestaurantCourseRepository,
+        },
+      ],
+    }).compile()
 
-    service = module.get<RestaurantCoursesService>(RestaurantCoursesService);
-  });
+    service = module.get<RestaurantCoursesService>(RestaurantCoursesService)
+    repository = module.get(getRepositoryToken(RestaurantCourse))
+  })
 
-  it('should be defined', () => {
-    expect(service).toBeDefined();
-  });
-});
+  describe('findAll', () => {
+    it('メソッドが定義されてる', () => {
+      expect(service.findAll).toBeDefined()
+    })
+
+    it('コースに関連するレストランのrelationの情報も含めて呼ばれる', async () => {
+      service.findAll()
+      expect(repository.find).toHaveBeenCalledWith({
+        relations: ['restaurant'],
+      })
+    })
+
+    it('repositroyを通じて取得された結果を返す', async () => {
+      const result = [{ id: 1, name: 'すし大崎' }]
+      repository.find.mockResolvedValue(result)
+      expect(await service.findAll()).toEqual(result)
+    })
+  })
+
+  describe('findOne', () => {
+    it('メソッドが定義されてる', () => {
+      expect(service.findOne).toBeDefined()
+    })
+
+    it('コースに関連するレストランのrelationの情報も含めて呼ばれる', async () => {
+      const id = 1
+      service.findOne(id)
+      expect(repository.findOne).toHaveBeenCalledWith({
+        relations: ['restaurant'],
+        where: { id },
+      })
+    })
+
+    it('repositroyを通じて取得された結果を返す', async () => {
+      const result = { id: 1, name: 'すし大崎' }
+      repository.findOne.mockResolvedValue(result)
+      expect(await service.findOne(result.id)).toEqual(result)
+    })
+  })
+})


### PR DESCRIPTION
## このPRについて

resolve #84 対応

## 説明

将来忘れなそうなので途中で調べていたことのメモ


### 依存module追加された場合

```
Nest can't resolve dependencies of the RestaurantCoursesService (?). Please make sure that the argument RestaurantCourseRepository at index [0] is available in the RootTestModule context.
```

というエラーが出ていた

- RestaurantCoursesServiceがRestaurantCourseRepositoryを依存している
- 雛形で生成されたテストコードだとテストモジュールの中でこのリポジトリの提供者が定義されていないため、上記のエラーが発生

ということで、以下のような形にしないといけない

```typescript
beforeEach(async () => {
  const module: TestingModule = await Test.createTestingModule({
    providers: [
      RestaurantCoursesService,
      // 以下の行でmocked repositoryを提供します
      {
        provide: 'RestaurantCourseRepository', // もしくは Repository<RestaurantCourse>
        useFactory: mockRestaurantCourseRepository,
      },
    ],
  }).compile()
```

### provide: getRepositoryToken(RestaurantCourse),

この部分最初よくわからなかったのでChatGPTと壁打ちしながら作業

> @InjectRepository()デコレータは、typeormの特定のリポジトリを注入するために使用されるカスタムトークンを作成します。
> そのため、このカスタムトークンを使用してテストモジュールにモックを提供する必要があります。


あと、getRepositoryTokenというメソッド名から、指定する引数はRepoistoryなのかと思ったけど

> getRepositoryToken(RestaurantCourse)の引数にはエンティティクラスRestaurantCourseを指定するのが正しいです。
> この関数は、特定のエンティティのためのリポジトリのカスタムトークンを返します。

ということ